### PR TITLE
Fix type error on getting source path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from setuptools import setup
 
 
-SOURCE = (Path(__file__).parents / "pyvoicechanger.py").read_text()
+SOURCE = (Path(__file__).parent / "pyvoicechanger.py").read_text()
 
 
 ##############################################################################


### PR DESCRIPTION
It should use `.parent` instead of `.parents`.

> ```
>   File "setup.py", line 39, in <module>
>     SOURCE = (Path(__file__).parents / "pyvoicechanger.py").read_text()
> TypeError: unsupported operand type(s) for /: '_PathParents' and 'str'
> ```